### PR TITLE
Fix characteristic string check

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,14 +118,20 @@ HTTP_HUMIDITY.prototype = {
     },
 
     handleNotification: function(body) {
-        if (!this.homebridgeService.testCharacteristic(body.characteristic)) {
-            this.log("Encountered unknown characteristic when handling notification (or characteristic which wasn't added to the service): " + body.characteristic);
-            return;
+        /** @namespace body.characteristic */
+        let characteristic;
+        switch(body.characteristic){
+            case "CurrentRelativeHumidity":
+                characteristic = Characteristic.CurrentRelativeHumidity;
+                break;
+            default:
+                this.log("Encountered unknown characteristic when handling notification (or characteristic which wasn't added to the service): " + body.characteristic);
+                return;
         }
 
         if (this.debug)
             this.log("Updating '" + body.characteristic + "' to new value: " + body.value);
-        this.homebridgeService.setCharacteristic(body.characteristic, body.value);
+        this.homebridgeService.setCharacteristic(characteristic, body.value);
     },
 
     getHumidity: function (callback) {


### PR DESCRIPTION
testCharacteristic("CurrentRelativeHumidity") returns false
testCharacteristic("Current Relative Humidity") returns true

Documentation states to use CurrentRelativeHumidity as the
Characteristic string value for both notifications and mqtt messages.
Best to keep that consistent as it has been historically like that.

This essentially reverts the change to this section which happened in
commit 9fb070699170e88fc418186fd316a99c8ac49661 "Adding support for
MQTT"